### PR TITLE
Vagrantfile: expose port 8101

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,8 @@ Vagrant.configure(2) do |config|
     vm_cfg.vm.provision "docker"
 
     config.vm.synced_folder '.', '/vagrant', type: :virtualbox
+    
+    config.vm.network "forwarded_port", guest: 8101, host: 8101
 
     vm_cfg.vm.provider :virtualbox do |v|
       v.name = vm_cfg.vm.hostname


### PR DESCRIPTION
Exporting the port enables engineers to use tools like postman installed on the e.g. macOS OS.