### PR TITLE
Maintenance: bump dependencies

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,7 +3,7 @@ flake8==3.5.0
 docker-py==1.10.6
 pytest-cov==2.6.0
 pytest-timeout==1.0.0
-pytest==3.8.2
-requests==2.20.0
+pytest==4.0.1
+requests==2.20.1
 lxml
 git+git://github.com/OpenIDC/pyoidc.git@7ad1cdbc64b5c6f52a29f1acc60a8184029a4e3c#egg=oic

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==1.0.5
 Cython==0.29.1
 git+https://github.com/cockroachdb/cockroachdb-python.git@298b70ce98459fd3ce43aa843ec2b3b16098df7b
 asn1crypto==0.24.0
-cryptography==2.3.1
+cryptography==2.4.2
 falcon==1.4.1
 gunicorn==19.9.0
 jsonschema==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alembic==1.0.0
+alembic==1.0.5
 Cython==0.29.1
 git+https://github.com/cockroachdb/cockroachdb-python.git@298b70ce98459fd3ce43aa843ec2b3b16098df7b
 asn1crypto==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic==1.0.0
-Cython==0.28.5
+Cython==0.29.1
 git+https://github.com/cockroachdb/cockroachdb-python.git@298b70ce98459fd3ce43aa843ec2b3b16098df7b
 asn1crypto==0.24.0
 cryptography==2.3.1
@@ -10,8 +10,8 @@ passlib==1.7.1
 PyJWT==1.6.4
 python-jose==3.0.1
 PyYAML==3.12
-psycopg2==2.7.5
+psycopg2==2.7.6.1
 retrying==1.3.3
 setproctitle==1.1.10
-sqlalchemy==1.2.12
+sqlalchemy==1.2.14
 sqlalchemy-utils==0.33.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ psycopg2==2.7.6.1
 retrying==1.3.3
 setproctitle==1.1.10
 sqlalchemy==1.2.14
-sqlalchemy-utils==0.33.5
+sqlalchemy-utils==0.33.8


### PR DESCRIPTION
Carefully selected dependency bumps for Bouncer itself (Cython, the 0.29.x release looks good now and psycopg2, and sqlalchemy maintenance releases). Also bumping test runner dependencies.