### PR TITLE
Support devkit and running tests on macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,9 @@ RUN set -ex \
         dnsutils net-tools less \
         gcc \
         python3-dev \
-        nmap
+        nmap \
+        nano \
+        less
 
 # Upgrading pip/setuptools and making the upgrade actually apply in the
 # following filesystem layers works more reliable when using a virtualenv for

--- a/common.mk
+++ b/common.mk
@@ -75,6 +75,7 @@ DEVKIT_COMMON_DOCKER_OPTS := --name $(DEVKIT_CONTAINER_NAME) \
 	-e PYTHONDONTWRITEBYTECODE=true \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v $(BOUNCER_LOCAL_PATH):$(BOUNCER_CTR_MOUNT) \
+	--tmpfs /gunicorn_tmp \
 	-v /tmp:/tmp
 
 

--- a/common.mk
+++ b/common.mk
@@ -67,7 +67,7 @@ BOUNCER_CTR_MOUNT := /usr/local/src/bouncer
 # bridge networking mode and set up the custom DNS name
 # `bouncer-test-hostmachine` (via the --add-host mechanism) which can be used
 # for reaching the host machine.
-DOCKER_NETWORK_HOST_IP=$(shell ip addr show docker0 | grep 'inet\b' | awk '{print $$2}' | cut -d/ -f1)
+DOCKER_NETWORK_HOST_IP=$(shell docker network inspect bridge -f "{{ with (index .IPAM.Config 0) }}{{ .Gateway }}{{ end }}")
 DEVKIT_COMMON_DOCKER_OPTS := --name $(DEVKIT_CONTAINER_NAME) \
 	-p 8101:8101 \
 	--add-host="bouncer-test-hostmachine:${DOCKER_NETWORK_HOST_IP}" \

--- a/tests/gunicorn-testconfig.py
+++ b/tests/gunicorn-testconfig.py
@@ -5,6 +5,7 @@ import cProfile
 import os
 import sys
 import traceback
+from pathlib import Path
 
 """
 Gunicorn configuration module.
@@ -34,6 +35,17 @@ backlog = 2048
 
 # Instruct Gunicorn to not reload upon source file modification.
 reload = False
+
+
+# When running in a devkit container the special `/gunicorn_tmp` path is created
+# in container with docker run `--tmpfs` mount. As the default `/tmp` is shared
+# between containers and is mounted from the host system the tests were failing
+# on macOS and Docker for Mac setup.
+# See: http://docs.gunicorn.org/en/stable/settings.html#worker-tmp-dir
+# See: http://docs.gunicorn.org/en/stable/faq.html#blocking-os-fchmod
+gunicorn_tmp_dir = Path('/gunicorn_tmp')
+if gunicorn_tmp_dir.exists():
+    worker_tmp_dir = str(gunicorn_tmp_dir)
 
 
 # Note(JP): Custom configuration parameters, controlling worker process


### PR DESCRIPTION
This patch aims to provide support for `devkit` container running on `macOS`.

To achieve that the changes include:
* Replace Linux specific `ip` command use to determine `docker0` bridge network IP address
* Create `/gunicorn_tmp` with `tmpfs` mount in `devkit` container
* Configure `gunicorn` to use `/gunicorn_tmp` as the `worker_tmp_dir`