### PR TITLE
Add back missing redirect_uri to Auth0 OIDC provider

### DIFF
--- a/bouncer/app/oidcidtokenlogin.py
+++ b/bouncer/app/oidcidtokenlogin.py
@@ -44,7 +44,7 @@ def get_login_provider_items_from_database_cfgitems(_):
             "config": {
                 # Note(JP): it's actually Admin Router which starts some magic
                 # at this endpoint. Bouncer does not actually start the flow.
-                "start_flow_url": "/login"
+                "start_flow_url": "/login?redirect_uri=urn:ietf:wg:oauth:2.0:oob"
             }
         }
     }

--- a/tests/app/test_app_http_auth_providers.py
+++ b/tests/app/test_app_http_auth_providers.py
@@ -31,6 +31,8 @@ class TestListAuthProviders:
             'dcos-services',
             'dcos-oidc-auth0'
         ])
+        start_flow_url = d['dcos-oidc-auth0']['config']['start_flow_url']
+        assert 'redirect_uri' in start_flow_url
 
     def test_legacy_user_creation_with_meaningless_request_body(self):
         """Test for a special property of the `dcos-oidc-auth0` auth provider.


### PR DESCRIPTION
This PR adds back `?redirect_uri=urn:ietf:wg:oauth:2.0:oob` to the Auth0 OIDC provider.
```
{
        "dcos-oidc-auth0": {
            "description": "DC/OS Auth0-based SSO through Google, GitHub, or Microsoft",
            "authentication-type": "oidc-implicit-flow",
            "client-method": "browser-prompt-oidcidtoken-get-authtoken",
            "config": {
                # Note(JP): it's actually Admin Router which starts some magic
                # at this endpoint. Bouncer does not actually start the flow.
                "start_flow_url": "/login?redirect_uri=urn:ietf:wg:oauth:2.0:oob"
            }
        }
    }
```
According to https://openid.net/specs/openid-connect-core-1_0.html#ImplicitTokenValidation
The `redirect_uri` is a REQUIRED parameter for the `Implicit Flow`.

The PR also adds a test that the `redirect_uri` is present for the `dcos-auth0-oidc` provider.

Corresponding ticket: [DCOS_OSS-4637](https://jira.mesosphere.com/browse/DCOS_OSS-4637)