### PR TITLE
tests: bump CockroachDB container image to version 2.1.8

### DIFF
--- a/tests/containers/cockroach.py
+++ b/tests/containers/cockroach.py
@@ -19,7 +19,7 @@ from .containerbase import ContainerBase
 log = logging.getLogger(__name__)
 
 
-COCKROACH_IMAGE = 'cockroachdb/cockroach:v2.1.7'
+COCKROACH_IMAGE = 'cockroachdb/cockroach:v2.1.8'
 
 
 class ContainerCockroach(ContainerBase):


### PR DESCRIPTION
This is to see if this fails non-trivially, or if it maybe even passes!