### PR TITLE
Add no_retry decorator for web requests

### DIFF
--- a/bouncer/app/models/__init__.py
+++ b/bouncer/app/models/__init__.py
@@ -7,7 +7,7 @@ coupled with SQLAlchemy-based relational database management.
 """
 
 
-from .session import Database, dbsession, run_transaction
+from .session import Database, dbsession, no_retry_on_serializable_failure, run_transaction
 from .user import UserBase, User, UserType
 from .config import ConfigItem, ConfigKeyNotFound, ConfigKeyExists
 from .base import DeclarativeBase

--- a/bouncer/app/wsgiapp.py
+++ b/bouncer/app/wsgiapp.py
@@ -310,26 +310,41 @@ class RetryTransactions:
         self.resource = resource
 
     def on_get(self, req, resp, **params):
+        if hasattr(self.resource.on_get, 'no_retry'):
+            return self.resource.on_get(req, resp, **params)
+
         def wrapped_responder():
             return self.resource.on_get(req, resp, **params)
         return run_transaction(wrapped_responder)
 
     def on_put(self, req, resp, **params):
+        if hasattr(self.resource.on_put, 'no_retry'):
+            return self.resource.on_put(req, resp, **params)
+
         def wrapped_responder():
             return self.resource.on_put(req, resp, **params)
         return run_transaction(wrapped_responder)
 
     def on_post(self, req, resp, **params):
+        if hasattr(self.resource.on_post, 'no_retry'):
+            return self.resource.on_post(req, resp, **params)
+
         def wrapped_responder():
             return self.resource.on_post(req, resp, **params)
         return run_transaction(wrapped_responder)
 
     def on_patch(self, req, resp, **params):
+        if hasattr(self.resource.on_patch, 'no_retry'):
+            return self.resource.on_patch(req, resp, **params)
+
         def wrapped_responder():
             return self.resource.on_patch(req, resp, **params)
         return run_transaction(wrapped_responder)
 
     def on_delete(self, req, resp, **params):
+        if hasattr(self.resource.on_delete, 'no_retry'):
+            return self.resource.on_delete(req, resp, **params)
+
         def wrapped_responder():
             return self.resource.on_delete(req, resp, **params)
         return run_transaction(wrapped_responder)


### PR DESCRIPTION
With CockroachDB, we wrap all requests in a `run_transaction` call that retries the entire web request if committing changes would break the serialization guarantees.

This PR provides a decorator that can be used to turn this "automatic" retry off. This is required for changes to the `groupimport` operation in Enterprise. https://jira.mesosphere.com/browse/DCOS-55766

This would probably be better done as an explicit retry decorator on each call, except groupimport, but I'm keeping it simple for now.