### PR TITLE
Downgrade requests to 2.21.0

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,6 +4,6 @@ docker==3.7.3
 pytest-cov==2.10.0
 pytest-timeout==1.4.2
 pytest==4.6.11
-requests==2.24.0
+requests==2.21.0
 lxml
 git+git://github.com/OpenIDC/pyoidc.git@7ad1cdbc64b5c6f52a29f1acc60a8184029a4e3c#egg=oic


### PR DESCRIPTION
Upgrading to requests 2.24.0 in https://github.com/dcos/bouncer/pull/18 causes tests to fail in Enterprise Bouncer.

Investigation shows that requests 2.22.0 updated urllib3 dependency, and urllib3 appears to have changed its URL parsing so that `http://path/.` gets the `/.` trimmed off.

Revert to version 2.21.0 so the tests pass, while we look at how to fix this properly.
