### PR TITLE
Upgrade to CockroachDB 19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN set -ex \
         dnsutils net-tools less \
         gcc \
         python3-dev \
-        nmap \
+        ncat \
         nano \
         less
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# python:3.6.6 is based on buildpack-deps:stretch (Debian Stretch)
-FROM python:3.6.6
+FROM python:3.6.12
 
 # The unit test suite requires running the docker client binary. As the binary
 # from the host is usually linked against system libraries (which are usually

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ yyuu/pyenv-based workflow:
     #   https://github.com/yyuu/pyenv-virtualenv#installing-as-a-pyenv-plugin
 
     # Create custom local Python build and create a virtualenv from it.
-    pyenv install 3.6.6
-    pyenv virtualenv 3.6.6 venv366-bouncer
-    pyenv activate venv366-bouncer
+    pyenv install 3.6.12
+    pyenv virtualenv 3.6.12 venv3612-bouncer
+    pyenv activate venv3612-bouncer
 
     # cd to the Bouncer repository and install dependencies from PyPI.
     pip install -r requirements.txt --upgrade

--- a/tests/app/test_app_http_core.py
+++ b/tests/app/test_app_http_core.py
@@ -19,7 +19,7 @@ from tests.misc import Url
 # "Note that the assigned variable must be called pytestmark"
 # Assigning a list is not well-documented, found that here:
 # https://github.com/pytest-dev/pytest/issues/816#issuecomment-119545763
-pytestmark = [pytest.mark.app, pytest.mark.usefixtures("wsgi_app")]
+pytestmark = [pytest.mark.usefixtures("wsgi_app")]
 
 
 class TestMiddlewareHeaderValidation:

--- a/tests/containers/cockroach.py
+++ b/tests/containers/cockroach.py
@@ -19,7 +19,7 @@ from .containerbase import ContainerBase
 log = logging.getLogger(__name__)
 
 
-COCKROACH_IMAGE = 'cockroachdb/cockroach:v2.1.8'
+COCKROACH_IMAGE = 'cockroachdb/cockroach:v19.1.11'
 
 
 class ContainerCockroach(ContainerBase):


### PR DESCRIPTION
This change only affects how the Bouncer repo is tested. It has no effect on the versions used in DC/OS.