### PR TITLE
Pin pip to avoid new dependency resolver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN python -m pip install --upgrade 'virtualenv<20'
 RUN unset PYTHONPATH
 
 RUN virtualenv --no-site-packages /venv \
-    && /venv/bin/pip install --upgrade setuptools pip
+    && /venv/bin/pip install --upgrade setuptools 'pip<20.3'
 
 # Copy Bouncer's requirements files into the image (if they change,
 # the image needs to be rebuilt).


### PR DESCRIPTION
Keep pip below 20.3 to avoid new dependency resolver