### PR TITLE
Consistent Docker images and auto-yes apt install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.12
+FROM python:3.6.13
 
 # `apt-get update` and `apt-get install` are unreliable and http-redir service
 # seems to be unmaintained. Because of that there is some basic retrying logic
@@ -38,7 +38,7 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
 $(lsb_release -cs) \
 stable" \
     && apt-get update \
-    && apt-get install docker-ce-cli
+    && apt-get install -y docker-ce-cli
 
 # Upgrading pip/setuptools and making the upgrade actually apply in the
 # following filesystem layers works more reliable when using a virtualenv for

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ task_wrapper('mesos-sec', master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89
     } finally {
 
         stage('archive artifacts') {
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'gunicorn_*.outerr', fingerprint: true
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'gunicorn_*.outerr', fingerprint: false
         }
 
         stage('make clean'){

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ yyuu/pyenv-based workflow:
     #   https://github.com/yyuu/pyenv-virtualenv#installing-as-a-pyenv-plugin
 
     # Create custom local Python build and create a virtualenv from it.
-    pyenv install 3.6.12
-    pyenv virtualenv 3.6.12 venv3612-bouncer
-    pyenv activate venv3612-bouncer
+    pyenv install 3.6.13
+    pyenv virtualenv 3.6.13 venv36-bouncer
+    pyenv activate venv36-bouncer
 
     # cd to the Bouncer repository and install dependencies from PyPI.
     pip install -r requirements.txt --upgrade

--- a/tests/containers/pyoidc-op/Dockerfile
+++ b/tests/containers/pyoidc-op/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.11
+FROM python:3.6.13
 
 # Requirements for running pyoidc's OP2 demo:
 # * pip install https://pypi.python.org/pypi/oic


### PR DESCRIPTION
Use the same Python image everywhere.
Avoid interactive apt command.